### PR TITLE
fix:デプロイの為のESLintエラー修正

### DIFF
--- a/src/app/[recipe_id]/cook/TimerModal.tsx
+++ b/src/app/[recipe_id]/cook/TimerModal.tsx
@@ -93,11 +93,11 @@ const TimerModal = ({
               .then(() => {
                 setPlaying(true);
               })
-              .catch((error) => {
+              .catch((/*error*/) => {
                 setPlaying(true);
                 setTimeout(() => {
-                  reset()
-                },8000)
+                  reset();
+                }, 8000);
               });
           }
         } else {
@@ -247,14 +247,12 @@ const TimerModal = ({
           <div className="flex justify-between mt-2">
             <div
               className="bg-orange-400 rounded-full shadow-lg ml-4 py-1 px-2 font-semibold text-sm cursor-pointer text-white"
-
               onClick={() => start_stop()}
             >
               {start ? "ストップ" : "スタート"}
             </div>
             <div
               className="bg-orange-400 rounded-full shadow-lg mr-4 py-1 px-2 font-semibold text-sm cursor-pointer text-white"
-
               onClick={() => reset()}
             >
               リセット

--- a/src/app/conponents/Speech.tsx
+++ b/src/app/conponents/Speech.tsx
@@ -126,7 +126,7 @@ const Speech = ({
     {
       command: /.*(リセット).*/,
       callback: () => {
-        setTimerReset(!timerReset)
+        setTimerReset(!timerReset);
         resetTranscript();
         SpeechRecognition.startListening({ continuous: true });
       },
@@ -171,7 +171,7 @@ const Speech = ({
     transcript,
     listening,
     resetTranscript,
-    browserSupportsSpeechRecognition,
+    // browserSupportsSpeechRecognition,
   } = useSpeechRecognition({ commands });
 
   // ここの処理はなくても良さそう。認識が止まることがあれば戻す。

--- a/src/app/testSCR/page.tsx
+++ b/src/app/testSCR/page.tsx
@@ -1,16 +1,16 @@
 "use client";
-import { useEffect, useState, useRef} from "react";
-import { Recipe } from "../types";
-import { getPageRecipes } from "../utils/supabaseFunctions";
+import { useEffect, useState, useRef } from "react";
+// import { Recipe } from "../types";
+// import { getPageRecipes } from "../utils/supabaseFunctions";
 
 export default function MyComponent() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [page, setPage] = useState(1);
-  const [pageRecipe, setPageRecipe] = useState<Recipe[]>([]);
+  //   const [pageRecipe, setPageRecipe] = useState<Recipe[]>([]);
   const loader = useRef(null);
   useEffect(() => {
-    getPageRecipes(page,pageRecipe,setPageRecipe)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // getPageRecipes(page,pageRecipe,setPageRecipe)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page]);
 
   useEffect(() => {
@@ -29,9 +29,9 @@ export default function MyComponent() {
 
   return (
     <div>
-      {pageRecipe.map((item) => (
+      {/* {pageRecipe.map((item) => (
         <div key={item.id} className='mb-20'>id={item.id}{item.name}</div>
-      ))}
+      ))} */}
       <div ref={loader}>Loading more...</div>
     </div>
   );


### PR DESCRIPTION
 ### 修正内容
 - TimerModal.tsxの変数errorが未使用だったのでコメントアウト
 - Speech.tsxの変数browserSupportsSpeechRecognitionが未使用だったのでコメントアウト
 - testSCR/page.tsxの関数getPageRecipesの必要な引数が1つ足りなかったのでコメントアウト+それに関連するコードもコメントアウト
